### PR TITLE
Warn about grades overridden

### DIFF
--- a/cli/migrate.php
+++ b/cli/migrate.php
@@ -143,8 +143,14 @@ foreach ($activities as $hvpid => $info) {
         continue;
     }
     try {
-        tool_migratehvp2h5p\api::migrate_hvp2h5p($hvpid, $keeporiginal, $copy2cb);
-        mtrace("\t ...Successful\n");
+        $messages = tool_migratehvp2h5p\api::migrate_hvp2h5p($hvpid, $keeporiginal, $copy2cb);
+        if (empty($messages)) {
+            mtrace("\t ...Successful\n");
+        } else {
+            foreach ($messages as $message) {
+                mtrace("\t ...$message[0]\n");
+            }
+        }
     } catch (moodle_exception $e) {
         mtrace("\tException: ".$e->getMessage()."\n");
         mtrace("\t ...Failed!\n");

--- a/index.php
+++ b/index.php
@@ -53,8 +53,14 @@ $notices = [];
 if (!empty($activityids)) {
     foreach ($activityids as $activityid) {
         try {
-            api::migrate_hvp2h5p($activityid, $keeporiginal, $copy2cb);
-            $notices[] = [get_string('migrate_success', 'tool_migratehvp2h5p', $activityid), notification::NOTIFY_SUCCESS];
+            $messages = api::migrate_hvp2h5p($activityid, $keeporiginal, $copy2cb);
+            if (empty($messages)) {
+                // Use the default message when no message is raised by the migration method.
+                $notices[] = [get_string('migrate_success', 'tool_migratehvp2h5p', $activityid), notification::NOTIFY_SUCCESS];
+            } else {
+                // Merge message with previous notices.
+                $notices = array_merge($messages, $notices);
+            }
         } catch (moodle_exception $e) {
             $errormsg = get_string('migrate_fail', 'tool_migratehvp2h5p', $activityid);
             $errormsg .= ': '.$e->getMessage();

--- a/lang/en/tool_migratehvp2h5p.php
+++ b/lang/en/tool_migratehvp2h5p.php
@@ -39,6 +39,13 @@ $string['id'] = 'Id';
 $string['migrate'] = 'Migrate';
 $string['migrate_success'] = 'Hvp activity with id {$a} migrated successfully';
 $string['migrate_fail'] = 'Error migration hvp activity with id {$a}';
+$string['migrate_gradesoverridden'] = 'Original mod_hvp activity "{$a->name}", with id {$a->id}, migrated successfully. However,
+    it has some grading information overridden, such as feedback, which hasn\'t been migrated because the original activity is
+    configured with an invalid maximum grade (it has to be higher than 0 in order to be migrated to the gradebook).';
+$string['migrate_gradesoverridden_notdelete'] = 'Original mod_hvp activity "{$a->name}", with id {$a->id}, migrated successfully.
+    However, it has some grading information overridden, such as feedback, which hasn\'t been migrated because the original activity
+    is configured with an invalid maximum grade (it has to be higher than 0 in order to be migrated to the gradebook).
+    The original activity has been hidden instead of removing it.';
 $string['nohvpactivities'] = 'There are no mod_hvp activities to migrate to the mod_h5pactivity.';
 $string['pluginname'] = 'Migrate content from mod_hvp to mod_h5pactivity';
 $string['keeporiginal'] = 'Select what to do with the original activity once migrated';


### PR DESCRIPTION
When mod_hvp is configured with a maximum grade set to 0, grades won't be migrated. A warning has been added to let admins know this situation. Besides, to avoid removing the existing feedback, these activities will be hidden instead of deleting them.